### PR TITLE
Use remote data

### DIFF
--- a/00-download-compress-hycom.ipynb
+++ b/00-download-compress-hycom.ipynb
@@ -2,6 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "d99e27e3",
+   "metadata": {},
+   "source": [
+    "# ESSE NOTEBOOK NÃO DEVE SER RODADO! ELE EXISTE APENAS PARA DOCUMENTAR COMO OBTIVEMOS OS DADOS DO HYCOM!!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4ef8858c",
    "metadata": {},
    "source": [
@@ -82,24 +90,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "year = \"2016\"\n",
+    "# Filter for year and month b/c we do not want to download everything in one go.\n",
+    "year, month = \"2016\", \"12\"\n",
     "\n",
     "url = f\"http://data.hycom.org/datasets/GLBu0.08/expt_91.2/data/hindcasts/{year}\"\n",
-    "urls = url_lister(url)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2d943c06",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# filter ony the velocity files.\n",
+    "urls = url_lister(url)\n",
+    "\n",
+    "# Filter ony the velocity files, chanfe it to t000_ts3z.nc for temperature and salinity.\n",
     "fnames = [fname for fname in urls if fname.endswith(\"t000_uv3z.nc\")]\n",
     "\n",
-    "# filter for month b/c we do not want to download everything in one go.\n",
-    "month = \"12\"\n",
     "name_list = set([fname for fname in fnames if fname.startswith(f\"hycom_glb_912_{year}{month}\")])"
    ]
   },

--- a/01-slice-aggregate-hycom.ipynb
+++ b/01-slice-aggregate-hycom.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "bbf2a30e",
+   "metadata": {},
+   "source": [
+    "# ESSE NOTEBOOK NÃO DEVE SER RODADO! ELE EXISTE APENAS PARA DOCUMENTAR COMO AGREGAMOS OS DADOS DO HYCOM APÓS O DOWNLOAD FEITO COM `00-download-compress-hycom.ipynb`"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "57e31678",

--- a/environment.yaml
+++ b/environment.yaml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3
   - cartopy
+  - cf_xarray
   - cftime
   - folium
   - geopandas
@@ -14,6 +15,7 @@ dependencies:
   - netcdf4
   - numpy
   - pandas
+  - pooch
   - shapely
   - windrose
   - xarray


### PR DESCRIPTION
@juoceano coloquei uma nota que os notebooks 00 e 01 são apenas para fazer o download e preparo dos dados. Não devem ser rodados pq partimos do notebook 02 com os dados prontos. Eles existem apenas como documentação do que foi feito.

No notebook 02 eu leio o arquivo do HyCOM final de Dez-2016 até Dez-2017 e faço as médias sazonais.